### PR TITLE
Change py-pip to py3-pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk update \
         curl \
         bash \
         python3 \
-        py-pip \
+        py3-pip \
         groff \
         less \
         mailcap \


### PR DESCRIPTION
Issue : 

`File "/usr/lib/python3.9/site-packages/awscli/table.py", line 17, in <module>
import colorama
ModuleNotFoundError: No module named 'colorama' `

py3-pip should fix module issues.